### PR TITLE
Fix the didStartSwiping delegate selector

### DIFF
--- a/RMSwipeTableViewCell.m
+++ b/RMSwipeTableViewCell.m
@@ -53,7 +53,7 @@
     CGPoint translation = [panGestureRecognizer translationInView:panGestureRecognizer.view];
     CGPoint velocity = [panGestureRecognizer velocityInView:panGestureRecognizer.view];
     if (panGestureRecognizer.state == UIGestureRecognizerStateBegan && [panGestureRecognizer numberOfTouches] > 0) {
-        if ([self.delegate respondsToSelector:@selector(swipeTableViewCellDidStartSwiping)]) {
+        if ([self.delegate respondsToSelector:@selector(swipeTableViewCellDidStartSwiping:)]) {
             [self.delegate swipeTableViewCellDidStartSwiping:self];
         }
         [self animateContentViewForPoint:translation velocity:velocity];


### PR DESCRIPTION
The didStartSwiping delegate is never returned due to the selector method missing the colon.

if ([self.delegate respondsToSelector:@selector(swipeTableViewCellDidStartSwiping:)]) {
            [self.delegate swipeTableViewCellDidStartSwiping:self];
}

I added the colon to swipeTableViewCellDidStartSwiping and the delegate methods respond correctly.
