### PR TITLE
Reset cell on not ended gesture state

### DIFF
--- a/RMSwipeTableViewCell.m
+++ b/RMSwipeTableViewCell.m
@@ -97,7 +97,7 @@
         [self animateContentViewForPoint:actualTranslation velocity:velocity];
     } else if (panGestureRecognizer.state == UIGestureRecognizerStateChanged && [panGestureRecognizer numberOfTouches] > 0) {
         [self animateContentViewForPoint:actualTranslation velocity:velocity];
-	} else if (panGestureRecognizer.state == UIGestureRecognizerStateEnded) {
+	} else {
 		[self resetCellFromPoint:actualTranslation  velocity:velocity];
 	}
 }


### PR DESCRIPTION
`handlePanGesture` method shouldn't ignore Canceled and Failed states and must to reset cell as well as Ended state.
