### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#RMSwipeTableViewCell
+# RMSwipeTableViewCell
 
 `RMSwipeTableViewCell` is a drop-in `UITableViewCell` subclass that supports pan gestures as seen in apps such as Clear, Mailbox, Sparrow and many more.
 
@@ -12,13 +12,13 @@
 
 ![RMSwipeTableViewCelliOS7Demo Animation](https://raw.github.com/runmad/RMSwipeTableViewCell/master/RMSwipeTableViewCelliOS7DemoAnimation.gif)
 
-##Installing `RMSwipeTableViewCell`
+## Installing `RMSwipeTableViewCell`
 
 The example below and demo assumes you're compiling for iOS 6+. If you're supporting an older version of iOS use the appropriate methods for initializing and dequeuing the cells. `RMSwipeTableViewCell` is compatible with iOS 5 and above.
 
 `RMSwipeTableViewCell` includes two demos. The iOS 7 demo is an attempt to copy the "Delete Mode" behaviour seen in iOS 7 in the Messages.app. The demo is built with iOS 6 SDK.
 
-###Using CocoaPods
+### Using CocoaPods
 
 Add the following to your Podfile.
 
@@ -26,7 +26,7 @@ Add the following to your Podfile.
 pod 'RMSwipeTableViewCell'
 ```
 
-###Manually
+### Manually
 
 Clone the repository to your machine or add `RMSwipeTableViewCell` as a submodule to your project.
 
@@ -49,13 +49,13 @@ Add `RMSwipeTableViewCell.h` and `RMSwipeTableViewCell.m` to your project. Impor
 }
 ```
 
-##Using `RMSwipeTableViewCell`
+## Using `RMSwipeTableViewCell`
 
 `RMSwipeTableViewCell` can be used as-is, but you are required to customize the `backView` with subviews, etc. to suit your needs (see Subclassing `RMSwipeTableViewCell`).
 
 The `RMSwipeTableViewCellDemo` project provides an example of subclassing and customizing the cell with custom views and actions.
 
-###Properties
+### Properties
 
 `RMSwipeTableViewCell` lets you customize and control animations and panning gestures. The demo uses all default states.
 
@@ -71,13 +71,13 @@ CGFloat panElasticityStartingPoint; // When using panElasticity this property al
 UIColor *backViewbackgroundColor; // default is [UIColor colorWithWhite:0.92 alpha:1]
 ```
 
-##Subclassing `RMSwipeTableViewCell`
+## Subclassing `RMSwipeTableViewCell`
 
 Subclassing `RMSwipeTableViewCell` is the best way to customize the cell beyond the default properties and any delegate callbacks. Subclassing allows you to create subviews for the `backView`, extend properties if needed and override class methods.
 
 See the demo for an example of subclassing usage.
 
-##`RMSwipeTableViewCell` Delegate Methods
+## `RMSwipeTableViewCell` Delegate Methods
 
 `RMSwipeTableViewCell` has a number of (optional) delegate methods that provide easy extensibility for subclassing and controlling cell functionality. The delegate methods are straightforward and the demo project shows a few examples of usage.
 
@@ -100,26 +100,26 @@ All delegate methods that return the CGPoint location take into account the panO
 -(BOOL)swipeTableViewCellShouldCleanupBackView:(RMSwipeTableViewCell*)swipeTableViewCell;
 ```
 
-##Credit
+## Credit
 
 Developed by Rune Madsen ([@runmad] and [runmad.com]).
 
-##Feedback
+## Feedback
 
 I appreciate feedback. Create Github issues, pull requests or connect with me on Twitter.
 
 I'd love to see and hear from you if you use it in a project.
 
-##License
+## License
 
 `RMSwipeTableViewCell` is available under the MIT license. See the LICENSE file for more info.
 
-##Version History
+## Version History
 
-###0.6.1
+### 0.6.1
 * Updating demos to work better on iOS 7
 
-###0.6
+### 0.6
 * Cleaned up init logic
 * Add new delegate method `-(BOOL)swipeTableViewCellShouldCleanupBackView:(RMSwipeTableViewCell*)swipeTableViewCell;`
 * Add `panElasticityFactor`
@@ -128,26 +128,26 @@ I'd love to see and hear from you if you use it in a project.
 * Fixed `UIViewAnimationOption` warning
 * Updated demo with support for iOS 7 spring animations
 
-###0.5
+### 0.5
 * Made a few improvements to the backView and some logic
 * Added another demo to show off tweaking of appearance to match iOS 7 behaviour and UI
 
-###0.4
+### 0.4
 * Added `panElasticityStartingPoint` to allow for finer control of when elasticity (if enabled) goes into effect
 * Added .gif for the README to show off the class better on Github
 * Fixed some logic issues I found with the demo project
 
-###0.3
+### 0.3
 * Deprecated a number of delegate methods to improve the the translation values being returned
 * Set `RMSwipeTableViewCellAnimationType`s to match UIViewAnimationOptions to simplify logic
 
-###0.2
+### 0.2
 * Added velocity property to delegate callbacks
 * Added iOS 6 `UIScrollView` rubber banding algorithm (https://twitter.com/chpwn/status/291794740553338880)
 * Added podspec
 * Fixed a few issues
 
-###0.1
+### 0.1
 * Initial release
 
 [High Quality Video Example]: http://www.runmad.com/development/RMTableViewCellDemoVideo.mp4


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
